### PR TITLE
Add tests for orders API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ build
 git_push.sh
 build.sbt
 AndroidManifest.xml
+travis-ci/accounts.json

--- a/src/test/java/com/squareup/connect/api/CatalogApiTest.java
+++ b/src/test/java/com/squareup/connect/api/CatalogApiTest.java
@@ -10,7 +10,6 @@
  * Do not edit the class manually.
  */
 
-
 package com.squareup.connect.api;
 
 import com.squareup.connect.ApiClient;
@@ -23,21 +22,15 @@ import com.squareup.connect.models.BatchRetrieveCatalogObjectsRequest;
 import com.squareup.connect.models.BatchRetrieveCatalogObjectsResponse;
 import com.squareup.connect.models.BatchUpsertCatalogObjectsRequest;
 import com.squareup.connect.models.BatchUpsertCatalogObjectsResponse;
-import com.squareup.connect.models.CatalogCategory;
 import com.squareup.connect.models.CatalogDiscount;
-import com.squareup.connect.models.CatalogIdMapping;
 import com.squareup.connect.models.CatalogInfoResponse;
 import com.squareup.connect.models.CatalogItem;
-import com.squareup.connect.models.CatalogItemModifierListInfo;
 import com.squareup.connect.models.CatalogItemVariation;
-import com.squareup.connect.models.CatalogModifier;
-import com.squareup.connect.models.CatalogModifierList;
 import com.squareup.connect.models.CatalogObject;
 import com.squareup.connect.models.CatalogObjectBatch;
 import com.squareup.connect.models.CatalogQuery;
 import com.squareup.connect.models.CatalogQueryItemsForTax;
 import com.squareup.connect.models.CatalogQueryPrefix;
-import com.squareup.connect.models.CatalogTax;
 import com.squareup.connect.models.DeleteCatalogObjectResponse;
 import com.squareup.connect.models.ListCatalogResponse;
 import com.squareup.connect.models.Money;
@@ -52,24 +45,19 @@ import com.squareup.connect.models.UpsertCatalogObjectRequest;
 import com.squareup.connect.models.UpsertCatalogObjectResponse;
 import com.squareup.connect.utils.APITest;
 import com.squareup.connect.utils.Account;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-
 import static java.util.Arrays.asList;
-import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 /**
  * API tests for CatalogApi
@@ -79,133 +67,7 @@ public class CatalogApiTest extends APITest {
     private final ApiClient defaultClient = Configuration.getDefaultApiClient();
     private final CatalogApi api = new CatalogApi();
 
-    private static final CatalogObject beverages = new CatalogObject()
-        .type(CatalogObject.TypeEnum.CATEGORY)
-        .id("#Beverages")
-        .categoryData(new CatalogCategory()
-            .name("Beverages"));
-
-    private static final CatalogObject milks = new CatalogObject()
-        .type(CatalogObject.TypeEnum.MODIFIER_LIST)
-        .id("#Milks")
-        .modifierListData(new CatalogModifierList()
-            .name("Milks")
-            .modifiers(asList(new CatalogObject()
-                    .type(CatalogObject.TypeEnum.MODIFIER)
-                    .id("#WholeMilk")
-                    .modifierData(new CatalogModifier()
-                        .name("Whole Milk")),
-                new CatalogObject()
-                    .type(CatalogObject.TypeEnum.MODIFIER)
-                    .id("#SkimMilk")
-                    .modifierData(new CatalogModifier()
-                        .name("Skim Milk")),
-                new CatalogObject()
-                    .type(CatalogObject.TypeEnum.MODIFIER)
-                    .id("#SoyMilk")
-                    .modifierData(new CatalogModifier()
-                        .name("SoyMilk")
-                        .priceMoney(new Money().amount(50L).currency(Money.CurrencyEnum.USD))))));
-
-    private static final CatalogObject syrups = new CatalogObject()
-        .type(CatalogObject.TypeEnum.MODIFIER_LIST)
-        .id("#Syrups")
-        .modifierListData(new CatalogModifierList()
-            .name("Syrups")
-            .modifiers(asList(new CatalogObject()
-                    .type(CatalogObject.TypeEnum.MODIFIER)
-                    .id("#Hazelnut")
-                    .modifierData(new CatalogModifier()
-                        .name("Hazelnut")),
-                new CatalogObject()
-                    .type(CatalogObject.TypeEnum.MODIFIER)
-                    .id("#Vanilla")
-                    .modifierData(new CatalogModifier()
-                        .name("Vanilla")),
-                new CatalogObject()
-                    .type(CatalogObject.TypeEnum.MODIFIER)
-                    .id("#Chocolate")
-                    .modifierData(new CatalogModifier()
-                        .name("Chocolate")))));
-
-    private static final CatalogObject coffee = new CatalogObject()
-        .type(CatalogObject.TypeEnum.ITEM)
-        .id("#Coffee")
-        .presentAtAllLocations(true)
-        .itemData(new CatalogItem()
-            .name("Coffee")
-            .description("Hot bean juice")
-            .abbreviation("Co")
-            .categoryId("#Beverages")
-            .modifierListInfo(singletonList(new CatalogItemModifierListInfo().modifierListId("#Milks")))
-            .taxIds(singletonList("#SalesTax"))
-            .variations(asList(new CatalogObject()
-                    .type(CatalogObject.TypeEnum.ITEM_VARIATION)
-                    .id("#SmallCoffee")
-                    .presentAtAllLocations(true)
-                    .itemVariationData(new CatalogItemVariation()
-                        .itemId("#Coffee")
-                        .name("Small")
-                        .pricingType(CatalogItemVariation.PricingTypeEnum.FIXED_PRICING)
-                        .priceMoney(new Money().amount(195L).currency(Money.CurrencyEnum.USD))),
-                new CatalogObject()
-                    .type(CatalogObject.TypeEnum.ITEM_VARIATION)
-                    .id("#LargeCoffee")
-                    .presentAtAllLocations(true)
-                    .itemVariationData(new CatalogItemVariation()
-                        .itemId("#Coffee")
-                        .name("Large")
-                        .pricingType(CatalogItemVariation.PricingTypeEnum.FIXED_PRICING)
-                        .priceMoney(new Money().amount(250L).currency(Money.CurrencyEnum.USD)))))
-        );
-
-    private static final CatalogObject tea = new CatalogObject()
-        .type(CatalogObject.TypeEnum.ITEM)
-        .id("#Tea")
-        .presentAtAllLocations(true)
-        .itemData(new CatalogItem()
-            .name("Tea")
-            .description("Hot leaf juice")
-            .abbreviation("Te")
-            .categoryId("#Beverages")
-            .modifierListInfo(singletonList(new CatalogItemModifierListInfo().modifierListId("#Milks")))
-            .taxIds(singletonList("#SalesTax"))
-            .variations(asList(new CatalogObject()
-                    .type(CatalogObject.TypeEnum.ITEM_VARIATION)
-                    .id("#SmallTea")
-                    .presentAtAllLocations(true)
-                    .itemVariationData(new CatalogItemVariation()
-                        .itemId("#Tea")
-                        .name("Small")
-                        .pricingType(CatalogItemVariation.PricingTypeEnum.FIXED_PRICING)
-                        .priceMoney(new Money().amount(150L).currency(Money.CurrencyEnum.USD))),
-                new CatalogObject()
-                    .type(CatalogObject.TypeEnum.ITEM_VARIATION)
-                    .id("#LargeTea")
-                    .presentAtAllLocations(true)
-                    .itemVariationData(new CatalogItemVariation()
-                        .itemId("#Tea")
-                        .name("Large")
-                        .pricingType(CatalogItemVariation.PricingTypeEnum.FIXED_PRICING)
-                        .priceMoney(new Money().amount(200L).currency(Money.CurrencyEnum.USD)))))
-        );
-
-    private static final CatalogObject salesTax = new CatalogObject()
-        .type(CatalogObject.TypeEnum.TAX)
-        .id("#SalesTax")
-        .presentAtAllLocations(true)
-        .taxData(new CatalogTax()
-            .name("Sales Tax")
-            .calculationPhase(CatalogTax.CalculationPhaseEnum.SUBTOTAL_PHASE)
-            .inclusionType(CatalogTax.InclusionTypeEnum.ADDITIVE)
-            .percentage("5.0")
-            .appliesToCustomAmounts(true)
-            .enabled(true));
-
-    public static final List<CatalogObject> OBJECTS = asList(beverages, milks, syrups, coffee, tea, salesTax);
-
-    // Mapping from client to server id, refreshed before each test.
-    public Map<String,String> idMap = new HashMap<>();
+    private CatalogFixtures catalogFixtures;
 
     @Before
     public void setup() {
@@ -214,75 +76,37 @@ public class CatalogApiTest extends APITest {
         OAuth oauth2 = (OAuth) defaultClient.getAuthentication("oauth2");
         oauth2.setAccessToken(testAccount.accessToken);
 
-        try {
-            buildTestCatalog();
-        } catch (ApiException e) {
-            fail(e.getMessage());
-        }
+        catalogFixtures = CatalogFixtures.populateCatalog(api);
     }
 
     @After
-    public void tearDown() {
-        try {
-            deleteTestCatalog();
-        } catch (ApiException e) {
-            fail(e.getMessage());
-        }
-    }
-
-    private void buildTestCatalog() throws ApiException {
-        BatchUpsertCatalogObjectsResponse response = api.batchUpsertCatalogObjects(new BatchUpsertCatalogObjectsRequest()
-            .idempotencyKey(UUID.randomUUID().toString())
-            .addBatchesItem(new CatalogObjectBatch().objects(OBJECTS)));
-
-        for (CatalogIdMapping idMapping : response.getIdMappings()) {
-            idMap.put(idMapping.getClientObjectId(), idMapping.getObjectId());
-        }
-    }
-
-    private void deleteTestCatalog() throws ApiException {
-        String cursor = "";
-        List<String> objectsToDelete = new ArrayList<>();
-        while (true) {
-            ListCatalogResponse response = api.listCatalog(cursor, null);
-            for (CatalogObject object : response.getObjects()) {
-                objectsToDelete.add(object.getId());
-            }
-
-            cursor = response.getCursor();
-            if (cursor == null || cursor.isEmpty()) {
-                break;
-            }
-        }
-
-        while (objectsToDelete.size() > 0) {
-            int elements = Math.min(200, objectsToDelete.size());
-            BatchDeleteCatalogObjectsResponse response =
-                api.batchDeleteCatalogObjects(new BatchDeleteCatalogObjectsRequest()
-                    .objectIds(objectsToDelete.subList(0, elements)));
-            objectsToDelete = objectsToDelete.subList(elements, objectsToDelete.size());
-        }
+    public void tearDown() throws Exception {
+        catalogFixtures.close();
     }
 
     /**
-     * BatchDeleteCatalogObjects
-     * <p>
-     * Deletes a set of [CatalogItem](#type-catalogitem)s based on the provided list of target IDs and returns a set of successfully deleted IDs in the response. Deletion is a cascading event such that all children of the targeted object are also deleted. For example, deleting a CatalogItem will also delete all of its [CatalogItemVariation](#type-catalogitemvariation) children.  &#x60;BatchDeleteCatalogObjects&#x60; succeeds even if only a portion of the targeted IDs can be deleted. The response will only include IDs that were actually deleted.
+     * BatchDeleteCatalogObjects <p> Deletes a set of [CatalogItem](#type-catalogitem)s based on the
+     * provided list of target IDs and returns a set of successfully deleted IDs in the response.
+     * Deletion is a cascading event such that all children of the targeted object are also deleted.
+     * For example, deleting a CatalogItem will also delete all of its
+     * [CatalogItemVariation](#type-catalogitemvariation) children.  &#x60;BatchDeleteCatalogObjects&#x60;
+     * succeeds even if only a portion of the targeted IDs can be deleted. The response will only
+     * include IDs that were actually deleted.
      *
      * @throws ApiException if the Api call fails
      */
     @Test
     public void batchDeleteCatalogObjectsTest() throws ApiException {
-        String coffeeId = idMap.get("#Coffee");
-        String smallCoffeeId = idMap.get("#SmallCoffee");
-        String largeCoffeeId = idMap.get("#LargeCoffee");
-        String smallTeaId = idMap.get("#SmallTea");
+        String coffeeId = catalogFixtures.getObjectId(CatalogFixtures.COFFEE_CLIENT_ID);
+        String smallCoffeeId = catalogFixtures.getObjectId(CatalogFixtures.SMALL_COFFEE_CLIENT_ID);
+        String largeCoffeeId = catalogFixtures.getObjectId(CatalogFixtures.LARGE_COFFEE_CLIENT_ID);
+        String smallTeaId = catalogFixtures.getObjectId(CatalogFixtures.SMALL_TEA_CLIENT_ID);
 
         BatchDeleteCatalogObjectsRequest body = new BatchDeleteCatalogObjectsRequest()
             .objectIds(asList(coffeeId, smallTeaId));
         BatchDeleteCatalogObjectsResponse response = api.batchDeleteCatalogObjects(body);
 
-        assertEquals(4,response.getDeletedObjectIds().size());
+        assertEquals(4, response.getDeletedObjectIds().size());
         assertTrue(response.getDeletedObjectIds().contains(coffeeId));
         assertTrue(response.getDeletedObjectIds().contains(smallCoffeeId));
         assertTrue(response.getDeletedObjectIds().contains(largeCoffeeId));
@@ -290,18 +114,20 @@ public class CatalogApiTest extends APITest {
     }
 
     /**
-     * BatchRetrieveCatalogObjects
-     * <p>
-     * Returns a set of objects based on the provided ID. [CatalogItem](#type-catalogitem)s returned in the set include all of the child information including: all [CatalogItemVariation](#type-catalogitemvariation) objects, references to its [CatalogModifierList](#type-catalogmodifierlist) objects, and the ids of any [CatalogTax](#type-catalogtax) objects that apply to it.
+     * BatchRetrieveCatalogObjects <p> Returns a set of objects based on the provided ID.
+     * [CatalogItem](#type-catalogitem)s returned in the set include all of the child information
+     * including: all [CatalogItemVariation](#type-catalogitemvariation) objects, references to its
+     * [CatalogModifierList](#type-catalogmodifierlist) objects, and the ids of any
+     * [CatalogTax](#type-catalogtax) objects that apply to it.
      *
      * @throws ApiException if the Api call fails
      */
     @Test
     public void batchRetrieveCatalogObjectsTest() throws ApiException {
-        String coffeeId = idMap.get("#Coffee");
-        String salesTaxId = idMap.get("#SalesTax");
-        String beveragesId = idMap.get("#Beverages");
-        String milksId = idMap.get("#Milks");
+        String coffeeId = catalogFixtures.getObjectId(CatalogFixtures.COFFEE_CLIENT_ID);
+        String salesTaxId = catalogFixtures.getObjectId(CatalogFixtures.SALES_TAX_CLIENT_ID);
+        String beveragesId = catalogFixtures.getObjectId(CatalogFixtures.BEVERAGES_CLIENT_ID);
+        String milksId = catalogFixtures.getObjectId(CatalogFixtures.MILKS_CLIENT_ID);
 
         BatchRetrieveCatalogObjectsRequest body = new BatchRetrieveCatalogObjectsRequest()
             .addObjectIdsItem(coffeeId)
@@ -332,23 +158,57 @@ public class CatalogApiTest extends APITest {
         assertEquals(1, actualCoffee.getItemData().getTaxIds().size());
         assertEquals(salesTaxId, actualCoffee.getItemData().getTaxIds().get(0));
         assertEquals(1, actualCoffee.getItemData().getModifierListInfo().size());
-        assertEquals(milksId, actualCoffee.getItemData().getModifierListInfo().get(0).getModifierListId());
-        assertEquals(0, actualCoffee.getItemData().getModifierListInfo().get(0).getModifierOverrides().size());
-        assertNull(actualCoffee.getItemData().getModifierListInfo().get(0).getMinSelectedModifiers());
-        assertNull(actualCoffee.getItemData().getModifierListInfo().get(0).getMaxSelectedModifiers());
+        assertEquals(milksId,
+            actualCoffee.getItemData().getModifierListInfo().get(0).getModifierListId());
+        assertEquals(0,
+            actualCoffee.getItemData().getModifierListInfo().get(0).getModifierOverrides().size());
+        assertNull(
+            actualCoffee.getItemData().getModifierListInfo().get(0).getMinSelectedModifiers());
+        assertNull(
+            actualCoffee.getItemData().getModifierListInfo().get(0).getMaxSelectedModifiers());
         assertNull(actualCoffee.getItemData().getModifierListInfo().get(0).getEnabled());
         assertNull(actualCoffee.getItemData().getImageUrl());
 
         assertEquals(2, actualCoffee.getItemData().getVariations().size());
-        assertEquals("Small", actualCoffee.getItemData().getVariations().get(0).getItemVariationData().getName());
-        assertEquals(CatalogItemVariation.PricingTypeEnum.FIXED_PRICING, actualCoffee.getItemData().getVariations().get(0).getItemVariationData().getPricingType());
-        assertEquals(Long.valueOf(195), actualCoffee.getItemData().getVariations().get(0).getItemVariationData().getPriceMoney().getAmount());
-        assertEquals(Money.CurrencyEnum.USD, actualCoffee.getItemData().getVariations().get(0).getItemVariationData().getPriceMoney().getCurrency());
+        assertEquals("Small",
+            actualCoffee.getItemData().getVariations().get(0).getItemVariationData().getName());
+        assertEquals(CatalogItemVariation.PricingTypeEnum.FIXED_PRICING, actualCoffee.getItemData()
+            .getVariations()
+            .get(0)
+            .getItemVariationData()
+            .getPricingType());
+        assertEquals(Long.valueOf(195), actualCoffee.getItemData()
+            .getVariations()
+            .get(0)
+            .getItemVariationData()
+            .getPriceMoney()
+            .getAmount());
+        assertEquals(Money.CurrencyEnum.USD, actualCoffee.getItemData()
+            .getVariations()
+            .get(0)
+            .getItemVariationData()
+            .getPriceMoney()
+            .getCurrency());
 
-        assertEquals("Large", actualCoffee.getItemData().getVariations().get(1).getItemVariationData().getName());
-        assertEquals(CatalogItemVariation.PricingTypeEnum.FIXED_PRICING, actualCoffee.getItemData().getVariations().get(1).getItemVariationData().getPricingType());
-        assertEquals(Long.valueOf(250), actualCoffee.getItemData().getVariations().get(1).getItemVariationData().getPriceMoney().getAmount());
-        assertEquals(Money.CurrencyEnum.USD, actualCoffee.getItemData().getVariations().get(1).getItemVariationData().getPriceMoney().getCurrency());
+        assertEquals("Large",
+            actualCoffee.getItemData().getVariations().get(1).getItemVariationData().getName());
+        assertEquals(CatalogItemVariation.PricingTypeEnum.FIXED_PRICING, actualCoffee.getItemData()
+            .getVariations()
+            .get(1)
+            .getItemVariationData()
+            .getPricingType());
+        assertEquals(Long.valueOf(250), actualCoffee.getItemData()
+            .getVariations()
+            .get(1)
+            .getItemVariationData()
+            .getPriceMoney()
+            .getAmount());
+        assertEquals(Money.CurrencyEnum.USD, actualCoffee.getItemData()
+            .getVariations()
+            .get(1)
+            .getItemVariationData()
+            .getPriceMoney()
+            .getCurrency());
 
         assertNull(actualCoffee.getCategoryData());
         assertNull(actualCoffee.getItemVariationData());
@@ -364,9 +224,14 @@ public class CatalogApiTest extends APITest {
     }
 
     /**
-     * BatchUpsertCatalogObjects
-     * <p>
-     * Creates or updates up to 10,000 target objects based on the provided list of objects. The target objects are grouped into batches and each batch is inserted/updated in an all-or-nothing manner. If an object within a batch is malformed in some way, or violates a database constraint, the entire batch containing that item will be disregarded. However, other batches in the same request may still succeed. Each batch may contain up to 1,000 objects, and batches will be processed in order as long as the total object count for the request (items, variations, modifier lists, discounts, and taxes) is no more than 10,000.
+     * BatchUpsertCatalogObjects <p> Creates or updates up to 10,000 target objects based on the
+     * provided list of objects. The target objects are grouped into batches and each batch is
+     * inserted/updated in an all-or-nothing manner. If an object within a batch is malformed in
+     * some way, or violates a database constraint, the entire batch containing that item will be
+     * disregarded. However, other batches in the same request may still succeed. Each batch may
+     * contain up to 1,000 objects, and batches will be processed in order as long as the total
+     * object count for the request (items, variations, modifier lists, discounts, and taxes) is no
+     * more than 10,000.
      *
      * @throws ApiException if the Api call fails
      */
@@ -394,7 +259,8 @@ public class CatalogApiTest extends APITest {
                             .itemVariationData(new CatalogItemVariation()
                                 .itemId(itemId)
                                 .name("Regular")
-                                .pricingType(CatalogItemVariation.PricingTypeEnum.VARIABLE_PRICING)))));
+                                .pricingType(
+                                    CatalogItemVariation.PricingTypeEnum.VARIABLE_PRICING)))));
                 numObjects++;
             }
         }
@@ -408,52 +274,62 @@ public class CatalogApiTest extends APITest {
     }
 
     /**
-     * CatalogInfo
-     * <p>
-     * Returns information about the Square Catalog API, such as batch size limits for &#x60;BatchUpsertCatalogObjects&#x60;.
+     * CatalogInfo <p> Returns information about the Square Catalog API, such as batch size limits
+     * for &#x60;BatchUpsertCatalogObjects&#x60;.
      *
      * @throws ApiException if the Api call fails
      */
     @Test
     public void catalogInfoTest() throws ApiException {
         CatalogInfoResponse response = api.catalogInfo();
-        assertEquals(Integer.valueOf(1000), response.getLimits().getBatchUpsertMaxObjectsPerBatch());
+        assertEquals(Integer.valueOf(1000),
+            response.getLimits().getBatchUpsertMaxObjectsPerBatch());
         assertEquals(Integer.valueOf(10000), response.getLimits().getBatchUpsertMaxTotalObjects());
         assertEquals(Integer.valueOf(1000), response.getLimits().getBatchRetrieveMaxObjectIds());
         assertEquals(Integer.valueOf(1000), response.getLimits().getSearchMaxPageLimit());
         assertEquals(Integer.valueOf(200), response.getLimits().getBatchDeleteMaxObjectIds());
         assertEquals(Integer.valueOf(1000), response.getLimits().getUpdateItemTaxesMaxItemIds());
-        assertEquals(Integer.valueOf(1000), response.getLimits().getUpdateItemTaxesMaxTaxesToEnable());
-        assertEquals(Integer.valueOf(1000), response.getLimits().getUpdateItemTaxesMaxTaxesToDisable());
-        assertEquals(Integer.valueOf(1000), response.getLimits().getUpdateItemModifierListsMaxItemIds());
-        assertEquals(Integer.valueOf(1000), response.getLimits().getUpdateItemModifierListsMaxModifierListsToEnable());
-        assertEquals(Integer.valueOf(1000), response.getLimits().getUpdateItemModifierListsMaxModifierListsToDisable());
+        assertEquals(Integer.valueOf(1000),
+            response.getLimits().getUpdateItemTaxesMaxTaxesToEnable());
+        assertEquals(Integer.valueOf(1000),
+            response.getLimits().getUpdateItemTaxesMaxTaxesToDisable());
+        assertEquals(Integer.valueOf(1000),
+            response.getLimits().getUpdateItemModifierListsMaxItemIds());
+        assertEquals(Integer.valueOf(1000),
+            response.getLimits().getUpdateItemModifierListsMaxModifierListsToEnable());
+        assertEquals(Integer.valueOf(1000),
+            response.getLimits().getUpdateItemModifierListsMaxModifierListsToDisable());
     }
 
     /**
-     * DeleteCatalogObject
-     * <p>
-     * Deletes a single [CatalogObject](#type-catalogobject) based on the provided ID and returns the set of successfully deleted IDs in the response. Deletion is a cascading event such that all children of the targeted object are also deleted. For example, deleting a [CatalogItem](#type-catalogitem) will also delete all of its [CatalogItemVariation](#type-catalogitemvariation) children.
+     * DeleteCatalogObject <p> Deletes a single [CatalogObject](#type-catalogobject) based on the
+     * provided ID and returns the set of successfully deleted IDs in the response. Deletion is a
+     * cascading event such that all children of the targeted object are also deleted. For example,
+     * deleting a [CatalogItem](#type-catalogitem) will also delete all of its
+     * [CatalogItemVariation](#type-catalogitemvariation) children.
      *
      * @throws ApiException if the Api call fails
      */
     @Test
     public void deleteCatalogObjectTest() throws ApiException {
-        String coffeeId = idMap.get("#Coffee");
-        String smallCoffeeId = idMap.get("#SmallCoffee");
-        String largeCoffeeId = idMap.get("#LargeCoffee");
+        String coffeeId = catalogFixtures.getObjectId(CatalogFixtures.COFFEE_CLIENT_ID);
+        String smallCoffeeId = catalogFixtures.getObjectId(CatalogFixtures.SMALL_COFFEE_CLIENT_ID);
+        String largeCoffeeId = catalogFixtures.getObjectId(CatalogFixtures.LARGE_COFFEE_CLIENT_ID);
         DeleteCatalogObjectResponse response = api.deleteCatalogObject(coffeeId);
 
-        assertEquals(3,response.getDeletedObjectIds().size());
+        assertEquals(3, response.getDeletedObjectIds().size());
         assertTrue(response.getDeletedObjectIds().contains(coffeeId));
         assertTrue(response.getDeletedObjectIds().contains(smallCoffeeId));
         assertTrue(response.getDeletedObjectIds().contains(largeCoffeeId));
     }
 
     /**
-     * ListCatalog
-     * <p>
-     * Returns a list of [CatalogObject](#type-catalogobject)s that includes all objects of a set of desired types (for example, all [CatalogItem](#type-catalogitem) and [CatalogTax](#type-catalogtax) objects) in the catalog. The types parameter is specified as a comma-separated list of valid [CatalogObject](#type-catalogobject) types: &#x60;ITEM&#x60;, &#x60;ITEM_VARIATION&#x60;, &#x60;MODIFIER&#x60;, &#x60;MODIFIER_LIST&#x60;, &#x60;CATEGORY&#x60;, &#x60;DISCOUNT&#x60;, &#x60;TAX&#x60;.
+     * ListCatalog <p> Returns a list of [CatalogObject](#type-catalogobject)s that includes all
+     * objects of a set of desired types (for example, all [CatalogItem](#type-catalogitem) and
+     * [CatalogTax](#type-catalogtax) objects) in the catalog. The types parameter is specified as a
+     * comma-separated list of valid [CatalogObject](#type-catalogobject) types: &#x60;ITEM&#x60;,
+     * &#x60;ITEM_VARIATION&#x60;, &#x60;MODIFIER&#x60;, &#x60;MODIFIER_LIST&#x60;,
+     * &#x60;CATEGORY&#x60;, &#x60;DISCOUNT&#x60;, &#x60;TAX&#x60;.
      *
      * @throws ApiException if the Api call fails
      */
@@ -472,19 +348,22 @@ public class CatalogApiTest extends APITest {
                 break;
             }
         }
-        assertEquals(OBJECTS.size(), allObjects.size());
+        assertEquals(CatalogFixtures.OBJECTS.size(), allObjects.size());
     }
 
     /**
-     * RetrieveCatalogObject
-     * <p>
-     * Returns a single [CatalogItem](#type-catalogitem) as a [CatalogObject](#type-catalogobject) based on the provided ID. The returned object includes all of the relevant [CatalogItem](#type-catalogitem) information including: [CatalogItemVariation](#type-catalogitemvariation) children, references to its [CatalogModifierList](#type-catalogmodifierlist) objects, and the ids of any [CatalogTax](#type-catalogtax) objects that apply to it.
+     * RetrieveCatalogObject <p> Returns a single [CatalogItem](#type-catalogitem) as a
+     * [CatalogObject](#type-catalogobject) based on the provided ID. The returned object includes
+     * all of the relevant [CatalogItem](#type-catalogitem) information including:
+     * [CatalogItemVariation](#type-catalogitemvariation) children, references to its
+     * [CatalogModifierList](#type-catalogmodifierlist) objects, and the ids of any
+     * [CatalogTax](#type-catalogtax) objects that apply to it.
      *
      * @throws ApiException if the Api call fails
      */
     @Test
     public void retrieveCatalogObjectTest() throws ApiException {
-        String objectId = idMap.get("#Coffee");
+        String objectId = catalogFixtures.getObjectId(CatalogFixtures.COFFEE_CLIENT_ID);
         RetrieveCatalogObjectResponse response = api.retrieveCatalogObject(objectId, true);
 
         assertTrue(response.getErrors().isEmpty());
@@ -496,13 +375,17 @@ public class CatalogApiTest extends APITest {
         boolean gotSalesTax = false;
         boolean gotBeverages = false;
         for (CatalogObject relatedObject : response.getRelatedObjects()) {
-            if (relatedObject.getType() == CatalogObject.TypeEnum.MODIFIER_LIST && relatedObject.getModifierListData().getName().equals("Milks")) {
+            if (relatedObject.getType() == CatalogObject.TypeEnum.MODIFIER_LIST
+                && relatedObject.getModifierListData().getName().equals("Milks")) {
                 gotMilks = true;
             }
-            if (relatedObject.getType() == CatalogObject.TypeEnum.TAX && relatedObject.getTaxData().getName().equals("Sales Tax")) {
+            if (relatedObject.getType() == CatalogObject.TypeEnum.TAX && relatedObject.getTaxData()
+                .getName()
+                .equals("Sales Tax")) {
                 gotSalesTax = true;
             }
-            if (relatedObject.getType() == CatalogObject.TypeEnum.CATEGORY && relatedObject.getCategoryData().getName().equals("Beverages")) {
+            if (relatedObject.getType() == CatalogObject.TypeEnum.CATEGORY
+                && relatedObject.getCategoryData().getName().equals("Beverages")) {
                 gotBeverages = true;
             }
         }
@@ -512,9 +395,11 @@ public class CatalogApiTest extends APITest {
     }
 
     /**
-     * SearchCatalogObjects
-     * <p>
-     * Queries the targeted catalog using a variety of query types ([CatalogQuerySortedAttribute](#type-catalogquerysortedattribute), ([CatalogQueryExact](#type-catalogqueryexact, ([CatalogQueryRange](#type-catalogqueryrange), ([CatalogQueryText](#type-catalogquerytext), ([CatalogQueryItemsForTax](#type-catalogqueryitemsfortax), ([CatalogQueryItemsForModifierList](#type-catalogqueryitemsformodifierlist)).
+     * SearchCatalogObjects <p> Queries the targeted catalog using a variety of query types
+     * ([CatalogQuerySortedAttribute](#type-catalogquerysortedattribute),
+     * ([CatalogQueryExact](#type-catalogqueryexact, ([CatalogQueryRange](#type-catalogqueryrange),
+     * ([CatalogQueryText](#type-catalogquerytext), ([CatalogQueryItemsForTax](#type-catalogqueryitemsfortax),
+     * ([CatalogQueryItemsForModifierList](#type-catalogqueryitemsformodifierlist)).
      *
      * @throws ApiException if the Api call fails
      */
@@ -535,7 +420,9 @@ public class CatalogApiTest extends APITest {
 
         SearchCatalogObjectsRequest query2 = new SearchCatalogObjectsRequest()
             .query(new CatalogQuery()
-                .itemsForTaxQuery(new CatalogQueryItemsForTax().addTaxIdsItem(idMap.get("#SalesTax"))))
+                .itemsForTaxQuery(
+                    new CatalogQueryItemsForTax().addTaxIdsItem(
+                        catalogFixtures.getObjectId(CatalogFixtures.SALES_TAX_CLIENT_ID))))
             .includeDeletedObjects(false)
             .includeRelatedObjects(false);
         SearchCatalogObjectsResponse response2 = api.searchCatalogObjects(query2);
@@ -558,21 +445,26 @@ public class CatalogApiTest extends APITest {
     }
 
     /**
-     * UpdateItemModifierLists
-     * <p>
-     * Updates the [CatalogModifierList](#type-catalogmodifierlist) objects that apply to the targeted [CatalogItem](#type-catalogitem) without having to perform an upsert on the entire item.
+     * UpdateItemModifierLists <p> Updates the [CatalogModifierList](#type-catalogmodifierlist)
+     * objects that apply to the targeted [CatalogItem](#type-catalogitem) without having to perform
+     * an upsert on the entire item.
      *
      * @throws ApiException if the Api call fails
      */
     @Test
     public void updateItemModifierListsTest() throws ApiException {
-        String coffeeId = idMap.get("#Coffee");
-        String milksId = idMap.get("#Milks");
-        String syrupsId = idMap.get("#Syrups");
+        String coffeeId = catalogFixtures.getObjectId(CatalogFixtures.COFFEE_CLIENT_ID);
+        String milksId = catalogFixtures.getObjectId(CatalogFixtures.MILKS_CLIENT_ID);
+        String syrupsId = catalogFixtures.getObjectId("#Syrups");
 
         RetrieveCatalogObjectResponse objectBefore = api.retrieveCatalogObject(coffeeId, false);
         assertEquals(1, objectBefore.getObject().getItemData().getModifierListInfo().size());
-        assertEquals(milksId, objectBefore.getObject().getItemData().getModifierListInfo().get(0).getModifierListId());
+        assertEquals(milksId,
+            objectBefore.getObject()
+                .getItemData()
+                .getModifierListInfo()
+                .get(0)
+                .getModifierListId());
 
         UpdateItemModifierListsRequest body = new UpdateItemModifierListsRequest()
             .addItemIdsItem(coffeeId)
@@ -582,20 +474,21 @@ public class CatalogApiTest extends APITest {
 
         RetrieveCatalogObjectResponse objectAfter = api.retrieveCatalogObject(coffeeId, false);
         assertEquals(1, objectAfter.getObject().getItemData().getModifierListInfo().size());
-        assertEquals(syrupsId, objectAfter.getObject().getItemData().getModifierListInfo().get(0).getModifierListId());
+        assertEquals(syrupsId,
+            objectAfter.getObject().getItemData().getModifierListInfo().get(0).getModifierListId());
     }
 
     /**
-     * UpdateItemTaxes
-     * <p>
-     * Updates the [CatalogTax](#type-catalogtax) objects that apply to the targeted [CatalogItem](#type-catalogitem) without having to perform an upsert on the entire item.
+     * UpdateItemTaxes <p> Updates the [CatalogTax](#type-catalogtax) objects that apply to the
+     * targeted [CatalogItem](#type-catalogitem) without having to perform an upsert on the entire
+     * item.
      *
      * @throws ApiException if the Api call fails
      */
     @Test
     public void updateItemTaxesTest() throws ApiException {
-        String coffeeId = idMap.get("#Coffee");
-        String salesTaxId = idMap.get("#SalesTax");
+        String coffeeId = catalogFixtures.getObjectId(CatalogFixtures.COFFEE_CLIENT_ID);
+        String salesTaxId = catalogFixtures.getObjectId(CatalogFixtures.SALES_TAX_CLIENT_ID);
 
         RetrieveCatalogObjectResponse objectBefore = api.retrieveCatalogObject(coffeeId, false);
         assertEquals(1, objectBefore.getObject().getItemData().getTaxIds().size());

--- a/src/test/java/com/squareup/connect/api/CatalogFixtures.java
+++ b/src/test/java/com/squareup/connect/api/CatalogFixtures.java
@@ -1,0 +1,253 @@
+package com.squareup.connect.api;
+
+import com.squareup.connect.ApiException;
+import com.squareup.connect.models.BatchDeleteCatalogObjectsRequest;
+import com.squareup.connect.models.BatchUpsertCatalogObjectsRequest;
+import com.squareup.connect.models.BatchUpsertCatalogObjectsResponse;
+import com.squareup.connect.models.CatalogCategory;
+import com.squareup.connect.models.CatalogDiscount;
+import com.squareup.connect.models.CatalogIdMapping;
+import com.squareup.connect.models.CatalogItem;
+import com.squareup.connect.models.CatalogItemModifierListInfo;
+import com.squareup.connect.models.CatalogItemVariation;
+import com.squareup.connect.models.CatalogModifier;
+import com.squareup.connect.models.CatalogModifierList;
+import com.squareup.connect.models.CatalogObject;
+import com.squareup.connect.models.CatalogObjectBatch;
+import com.squareup.connect.models.CatalogTax;
+import com.squareup.connect.models.ListCatalogResponse;
+import com.squareup.connect.models.Money;
+import com.squareup.connect.models.Money.CurrencyEnum;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+
+/**
+ * Helper class for populating a usable catalog on the server.
+ */
+class CatalogFixtures implements AutoCloseable {
+
+    static final String COFFEE_CLIENT_ID = "#Coffee";
+    static final String SMALL_COFFEE_CLIENT_ID = "#SmallCoffee";
+    static final String LARGE_COFFEE_CLIENT_ID = "#LargeCoffee";
+    static final String SMALL_TEA_CLIENT_ID = "#SmallTea";
+    static final String WHOLE_MILK_CLIENT_ID = "#WholeMilk";
+    static final String BEVERAGES_CLIENT_ID = "#Beverages";
+    static final String MILKS_CLIENT_ID = "#Milks";
+    static final String SOY_MILK_CLIENT_ID = "#SoyMilk";
+    static final String AMOUNT_DISCOUNT_CLIENT_ID = "#AmountDiscount";
+    static final String SALES_TAX_CLIENT_ID = "#SalesTax";
+
+    static final CatalogObject BEVERAGES = new CatalogObject()
+        .type(CatalogObject.TypeEnum.CATEGORY)
+        .id("#Beverages")
+        .categoryData(new CatalogCategory()
+            .name("Beverages"));
+
+    static final CatalogObject MILKS = new CatalogObject()
+        .type(CatalogObject.TypeEnum.MODIFIER_LIST)
+        .id("#Milks")
+        .modifierListData(new CatalogModifierList()
+            .name("Milks")
+            .modifiers(asList(new CatalogObject()
+                    .type(CatalogObject.TypeEnum.MODIFIER)
+                    .id(WHOLE_MILK_CLIENT_ID)
+                    .modifierData(new CatalogModifier()
+                        .name("Whole Milk")),
+                new CatalogObject()
+                    .type(CatalogObject.TypeEnum.MODIFIER)
+                    .id("#SkimMilk")
+                    .modifierData(new CatalogModifier()
+                        .name("Skim Milk")),
+                new CatalogObject()
+                    .type(CatalogObject.TypeEnum.MODIFIER)
+                    .id(SOY_MILK_CLIENT_ID)
+                    .modifierData(new CatalogModifier()
+                        .name("SoyMilk")
+                        .priceMoney(new Money().amount(50L).currency(Money.CurrencyEnum.USD))))));
+
+    static final CatalogObject SYRUPS = new CatalogObject()
+        .type(CatalogObject.TypeEnum.MODIFIER_LIST)
+        .id("#Syrups")
+        .modifierListData(new CatalogModifierList()
+            .name("Syrups")
+            .modifiers(asList(new CatalogObject()
+                    .type(CatalogObject.TypeEnum.MODIFIER)
+                    .id("#Hazelnut")
+                    .modifierData(new CatalogModifier()
+                        .name("Hazelnut")),
+                new CatalogObject()
+                    .type(CatalogObject.TypeEnum.MODIFIER)
+                    .id("#Vanilla")
+                    .modifierData(new CatalogModifier()
+                        .name("Vanilla")),
+                new CatalogObject()
+                    .type(CatalogObject.TypeEnum.MODIFIER)
+                    .id("#Chocolate")
+                    .modifierData(new CatalogModifier()
+                        .name("Chocolate")))));
+
+    static final CatalogObject SMALL_COFFEE_ITEM_VARIATION = new CatalogObject()
+        .type(CatalogObject.TypeEnum.ITEM_VARIATION)
+        .id(SMALL_COFFEE_CLIENT_ID)
+        .presentAtAllLocations(true)
+        .itemVariationData(new CatalogItemVariation()
+            .itemId(COFFEE_CLIENT_ID)
+            .name("Small")
+            .pricingType(CatalogItemVariation.PricingTypeEnum.FIXED_PRICING)
+            .priceMoney(new Money().amount(195L).currency(Money.CurrencyEnum.USD)));
+
+    static final CatalogObject LARGE_COFFEE_ITEM_VARIATION = new CatalogObject()
+        .type(CatalogObject.TypeEnum.ITEM_VARIATION)
+        .id(LARGE_COFFEE_CLIENT_ID)
+        .presentAtAllLocations(true)
+        .itemVariationData(new CatalogItemVariation()
+            .itemId(COFFEE_CLIENT_ID)
+            .name("Large")
+            .pricingType(CatalogItemVariation.PricingTypeEnum.FIXED_PRICING)
+            .priceMoney(new Money().amount(250L).currency(Money.CurrencyEnum.USD)));
+
+    static final CatalogObject COFFEE_ITEM = new CatalogObject()
+        .type(CatalogObject.TypeEnum.ITEM)
+        .id(COFFEE_CLIENT_ID)
+        .presentAtAllLocations(true)
+        .itemData(new CatalogItem()
+            .name("Coffee")
+            .description("Hot bean juice")
+            .abbreviation("Co")
+            .categoryId("#Beverages")
+            .modifierListInfo(
+                singletonList(new CatalogItemModifierListInfo().modifierListId("#Milks")))
+            .taxIds(singletonList(SALES_TAX_CLIENT_ID))
+            .variations(asList(SMALL_COFFEE_ITEM_VARIATION, LARGE_COFFEE_ITEM_VARIATION)));
+
+    static final CatalogObject TEA = new CatalogObject()
+        .type(CatalogObject.TypeEnum.ITEM)
+        .id("#Tea")
+        .presentAtAllLocations(true)
+        .itemData(new CatalogItem()
+            .name("Tea")
+            .description("Hot leaf juice")
+            .abbreviation("Te")
+            .categoryId("#Beverages")
+            .modifierListInfo(
+                singletonList(new CatalogItemModifierListInfo().modifierListId("#Milks")))
+            .taxIds(singletonList(SALES_TAX_CLIENT_ID))
+            .variations(asList(new CatalogObject()
+                    .type(CatalogObject.TypeEnum.ITEM_VARIATION)
+                    .id("#SmallTea")
+                    .presentAtAllLocations(true)
+                    .itemVariationData(new CatalogItemVariation()
+                        .itemId("#Tea")
+                        .name("Small")
+                        .pricingType(CatalogItemVariation.PricingTypeEnum.FIXED_PRICING)
+                        .priceMoney(new Money().amount(150L).currency(Money.CurrencyEnum.USD))),
+                new CatalogObject()
+                    .type(CatalogObject.TypeEnum.ITEM_VARIATION)
+                    .id("#LargeTea")
+                    .presentAtAllLocations(true)
+                    .itemVariationData(new CatalogItemVariation()
+                        .itemId("#Tea")
+                        .name("Large")
+                        .pricingType(CatalogItemVariation.PricingTypeEnum.FIXED_PRICING)
+                        .priceMoney(new Money().amount(200L).currency(Money.CurrencyEnum.USD)))))
+        );
+
+    static final CatalogObject AMOUNT_DISCOUNT = new CatalogObject()
+        .type(CatalogObject.TypeEnum.DISCOUNT)
+        .id(AMOUNT_DISCOUNT_CLIENT_ID)
+        .discountData(new CatalogDiscount()
+            .name("50 cents off")
+            .amountMoney(new Money().amount(50L).currency(CurrencyEnum.USD)));
+
+    static final CatalogObject SALES_TAX = new CatalogObject()
+        .type(CatalogObject.TypeEnum.TAX)
+        .id(SALES_TAX_CLIENT_ID)
+        .presentAtAllLocations(true)
+        .taxData(new CatalogTax()
+            .name("Sales Tax")
+            .calculationPhase(CatalogTax.CalculationPhaseEnum.SUBTOTAL_PHASE)
+            .inclusionType(CatalogTax.InclusionTypeEnum.ADDITIVE)
+            .percentage("5.0")
+            .appliesToCustomAmounts(true)
+            .enabled(true));
+
+    static final List<CatalogObject> OBJECTS =
+        asList(BEVERAGES, MILKS, SYRUPS, COFFEE_ITEM, TEA, AMOUNT_DISCOUNT, SALES_TAX);
+
+    private final CatalogApi api;
+    private final Map<String, String> idMap = new HashMap<>();
+
+    private CatalogFixtures(CatalogApi api) {
+        this.api = api;
+
+        try {
+            buildTestCatalog();
+        } catch (ApiException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Create catalog objects on the server. To properly clean up these objects, call the
+     * {@link #close} method.
+     */
+    static CatalogFixtures populateCatalog(CatalogApi api) {
+        return new CatalogFixtures(api);
+    }
+
+    /**
+     * @param clientId Client ID of a catalog object.
+     * @return Server ID of the catalog object.
+     * @throws NullPointerException Thrown if this TestCatalog did not create an object with a
+     * matching client ID.
+     */
+    String getObjectId(String clientId) {
+        String serverId = idMap.get(clientId);
+        if (serverId == null) {
+            throw new NullPointerException(clientId);
+        }
+
+        return serverId;
+    }
+
+    /**
+     * Deletes all catalog objects that were created when instantiating this TestCatalog.
+     */
+    @Override public void close() throws Exception {
+        String cursor = "";
+        List<String> objectsToDelete = new ArrayList<>();
+        do {
+            ListCatalogResponse response = api.listCatalog(cursor, null);
+            for (CatalogObject object : response.getObjects()) {
+                objectsToDelete.add(object.getId());
+            }
+
+            cursor = response.getCursor();
+        } while (cursor != null && !cursor.isEmpty());
+
+        while (objectsToDelete.size() > 0) {
+            int elements = Math.min(200, objectsToDelete.size());
+
+            api.batchDeleteCatalogObjects(new BatchDeleteCatalogObjectsRequest()
+                .objectIds(objectsToDelete.subList(0, elements)));
+            objectsToDelete = objectsToDelete.subList(elements, objectsToDelete.size());
+        }
+    }
+
+    private void buildTestCatalog() throws ApiException {
+        BatchUpsertCatalogObjectsResponse
+            response = api.batchUpsertCatalogObjects(new BatchUpsertCatalogObjectsRequest()
+            .idempotencyKey(UUID.randomUUID().toString())
+            .addBatchesItem(new CatalogObjectBatch().objects(OBJECTS)));
+
+        for (CatalogIdMapping idMapping : response.getIdMappings()) {
+            idMap.put(idMapping.getClientObjectId(), idMapping.getObjectId());
+        }
+    }
+}

--- a/src/test/java/com/squareup/connect/api/CustomersApiTest.java
+++ b/src/test/java/com/squareup/connect/api/CustomersApiTest.java
@@ -108,7 +108,7 @@ public class CustomersApiTest extends APITest {
         assertTrue(response.getErrors().isEmpty());
         assertNotNull(response.getCustomer().getId());
     }
-    
+
     /**
      * CreateCustomerCard
      *
@@ -142,7 +142,7 @@ public class CustomersApiTest extends APITest {
         assertTrue(response.getErrors().isEmpty());
         assertNotNull(response.getCard().getId());
     }
-    
+
     /**
      * DeleteCustomer
      *
@@ -162,7 +162,7 @@ public class CustomersApiTest extends APITest {
 
         assertTrue(response.getErrors().isEmpty());
     }
-    
+
     /**
      * DeleteCustomerCard
      *
@@ -198,7 +198,7 @@ public class CustomersApiTest extends APITest {
 
         assertTrue(response.getErrors().isEmpty());
     }
-    
+
     /**
      * ListCustomers
      *
@@ -214,7 +214,7 @@ public class CustomersApiTest extends APITest {
 
         // TODO: test validations
     }
-    
+
     /**
      * RetrieveCustomer
      *
@@ -235,7 +235,7 @@ public class CustomersApiTest extends APITest {
         assertTrue(response.getErrors().isEmpty());
         assertEquals(customer.getId(), response.getCustomer().getId());
     }
-    
+
     /**
      * UpdateCustomer
      *
@@ -260,5 +260,5 @@ public class CustomersApiTest extends APITest {
         assertTrue(response.getErrors().isEmpty());
         assertEquals("New.Amelia.Earhart@example.com", response.getCustomer().getEmailAddress());
     }
-    
+
 }

--- a/src/test/java/com/squareup/connect/api/OrdersApiTest.java
+++ b/src/test/java/com/squareup/connect/api/OrdersApiTest.java
@@ -1,0 +1,174 @@
+package com.squareup.connect.api;
+
+import com.squareup.connect.ApiClient;
+import com.squareup.connect.Configuration;
+import com.squareup.connect.auth.OAuth;
+import com.squareup.connect.models.CatalogModifier;
+import com.squareup.connect.models.CatalogObject;
+import com.squareup.connect.models.CreateOrderRequest;
+import com.squareup.connect.models.CreateOrderRequestDiscount;
+import com.squareup.connect.models.CreateOrderRequestLineItem;
+import com.squareup.connect.models.CreateOrderRequestModifier;
+import com.squareup.connect.models.CreateOrderRequestTax;
+import com.squareup.connect.models.CreateOrderResponse;
+import com.squareup.connect.models.Money;
+import com.squareup.connect.models.Money.CurrencyEnum;
+import com.squareup.connect.models.Order;
+import com.squareup.connect.models.OrderLineItem;
+import com.squareup.connect.models.OrderLineItemDiscount;
+import com.squareup.connect.models.OrderLineItemDiscount.ScopeEnum;
+import com.squareup.connect.models.OrderLineItemModifier;
+import com.squareup.connect.models.OrderLineItemTax;
+import com.squareup.connect.models.OrderLineItemTax.TypeEnum;
+import com.squareup.connect.utils.APITest;
+import com.squareup.connect.utils.Account;
+import java.util.UUID;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * API tests for OrdersApi.
+ */
+public class OrdersApiTest extends APITest {
+    private final ApiClient defaultClient = Configuration.getDefaultApiClient();
+    private final OrdersApi api = new OrdersApi();
+
+    private String locationId;
+    private CatalogFixtures catalogFixtures;
+
+    @Before
+    public void setup() throws Exception {
+        // The Catalog API does not run in the sandbox.
+        Account testAccount = accounts.get("US-Prod");
+        OAuth oauth2 = (OAuth) defaultClient.getAuthentication("oauth2");
+        oauth2.setAccessToken(testAccount.accessToken);
+
+        catalogFixtures = CatalogFixtures.populateCatalog(new CatalogApi());
+
+        locationId = new LocationsApi().listLocations().getLocations().get(0).getId();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        catalogFixtures.close();
+    }
+
+    @Test
+    public void createOrderWithCustomItems() throws Exception {
+        CreateOrderRequest request = new CreateOrderRequest()
+            .idempotencyKey(UUID.randomUUID().toString())
+            .referenceId("order ref id")
+            .addLineItemsItem(new CreateOrderRequestLineItem()
+                .name("Espresso")
+                .quantity("2")
+                .note("some note")
+                .basePriceMoney(new Money()
+                    .amount(2_00L)
+                    .currency(CurrencyEnum.USD)));
+
+        CreateOrderResponse response = api.createOrder(locationId, request);
+
+        Order actual = response.getOrder();
+        assertNotNull(actual);
+
+        Order expected = new Order()
+            .id(actual.getId())
+            .locationId(locationId)
+            .referenceId(request.getReferenceId())
+            .addLineItemsItem(new OrderLineItem()
+                .name(request.getLineItems().get(0).getName())
+                .quantity(request.getLineItems().get(0).getQuantity())
+                .note(request.getLineItems().get(0).getNote())
+                .basePriceMoney(request.getLineItems().get(0).getBasePriceMoney())
+                .grossSalesMoney(new Money().amount(4_00L).currency(CurrencyEnum.USD))
+                .totalTaxMoney(new Money().amount(0L).currency(CurrencyEnum.USD))
+                .totalDiscountMoney(new Money().amount(0L).currency(CurrencyEnum.USD))
+                .totalMoney(new Money().amount(4_00L).currency(CurrencyEnum.USD)))
+            .totalTaxMoney(new Money().amount(0L).currency(CurrencyEnum.USD))
+            .totalDiscountMoney(new Money().amount(0L).currency(CurrencyEnum.USD))
+            .totalMoney(new Money().amount(4_00L).currency(CurrencyEnum.USD));
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void createOrderWithCatalogItems() throws Exception {
+        CreateOrderRequest request = new CreateOrderRequest()
+            .idempotencyKey(UUID.randomUUID().toString())
+            .referenceId("order ref id with catalog")
+            .addLineItemsItem(new CreateOrderRequestLineItem()
+                .catalogObjectId(catalogFixtures.getObjectId(CatalogFixtures.LARGE_COFFEE_CLIENT_ID))
+                .quantity("2")
+                .addModifiersItem(new CreateOrderRequestModifier()
+                    .catalogObjectId(catalogFixtures.getObjectId(CatalogFixtures.SOY_MILK_CLIENT_ID)))
+                .addDiscountsItem(new CreateOrderRequestDiscount()
+                    .catalogObjectId(
+                        catalogFixtures.getObjectId(CatalogFixtures.AMOUNT_DISCOUNT_CLIENT_ID)))
+                .addTaxesItem(new CreateOrderRequestTax()
+                    .catalogObjectId(catalogFixtures.getObjectId(CatalogFixtures.SALES_TAX_CLIENT_ID))));
+
+        CreateOrderResponse response = api.createOrder(locationId, request);
+
+        assertEquals(0, response.getErrors().size());
+
+        Order actual = response.getOrder();
+        assertNotNull(actual);
+
+        CatalogModifier soyMilkModifier = CatalogFixtures.MILKS.getModifierListData().getModifiers()
+            .stream()
+            .filter(m -> CatalogFixtures.SOY_MILK_CLIENT_ID.equals(m.getId()))
+            .map(CatalogObject::getModifierData)
+            .findFirst()
+            .get();
+
+        Order expected = new Order()
+            .id(actual.getId())
+            .locationId(locationId)
+            .referenceId(request.getReferenceId())
+            .addLineItemsItem(new OrderLineItem()
+                .name(CatalogFixtures.COFFEE_ITEM.getItemData().getName())
+                .quantity(request.getLineItems().get(0).getQuantity())
+                .catalogObjectId(catalogFixtures.getObjectId(CatalogFixtures.LARGE_COFFEE_CLIENT_ID))
+                .variationName(
+                    CatalogFixtures.LARGE_COFFEE_ITEM_VARIATION.getItemVariationData().getName())
+                .addModifiersItem(new OrderLineItemModifier()
+                    .catalogObjectId(catalogFixtures.getObjectId(CatalogFixtures.SOY_MILK_CLIENT_ID))
+                    .name(soyMilkModifier.getName())
+                    .basePriceMoney(soyMilkModifier.getPriceMoney())
+                    .totalPriceMoney(
+                        new Money().amount(1_00L).currency(CurrencyEnum.USD))) // $0.50 * 2
+                .addDiscountsItem(new OrderLineItemDiscount()
+                    .catalogObjectId(catalogFixtures.getObjectId(CatalogFixtures.AMOUNT_DISCOUNT_CLIENT_ID))
+                    .name(CatalogFixtures.AMOUNT_DISCOUNT.getDiscountData().getName())
+                    .type(OrderLineItemDiscount.TypeEnum.FIXED_AMOUNT)
+                    .amountMoney(CatalogFixtures.AMOUNT_DISCOUNT.getDiscountData().getAmountMoney())
+                    .appliedMoney(CatalogFixtures.AMOUNT_DISCOUNT.getDiscountData().getAmountMoney())
+                    .scope(ScopeEnum.LINE_ITEM))
+                .addTaxesItem(new OrderLineItemTax()
+                    .catalogObjectId(catalogFixtures.getObjectId(CatalogFixtures.SALES_TAX_CLIENT_ID))
+                    .name(CatalogFixtures.SALES_TAX.getTaxData().getName())
+                    .type(TypeEnum.ADDITIVE)
+                    .percentage(CatalogFixtures.SALES_TAX.getTaxData().getPercentage())
+                    .appliedMoney(
+                        // ((($2.50 + $0.50) * 2) - $0.50) * 5% = $0.28
+                        new Money().amount(28L).currency(CurrencyEnum.USD)))
+                .basePriceMoney(
+                    CatalogFixtures.LARGE_COFFEE_ITEM_VARIATION.getItemVariationData().getPriceMoney())
+                .grossSalesMoney(
+                    new Money().amount(6_00L).currency(CurrencyEnum.USD)) // ($2.50 + $0.5) * 2 = $6
+                .totalTaxMoney(
+                    // ($6 - $0.50) *  5% additive = $0.28
+                    new Money().amount(28L).currency(CurrencyEnum.USD))
+                .totalDiscountMoney(new Money().amount(50L).currency(CurrencyEnum.USD))
+                .totalMoney(new Money().amount(5_78L).currency(CurrencyEnum.USD)))
+            .totalTaxMoney(new Money().amount(28L).currency(CurrencyEnum.USD))
+            .totalDiscountMoney(new Money().amount(50L).currency(CurrencyEnum.USD))
+            .totalMoney(new Money().amount(5_78L).currency(CurrencyEnum.USD));
+
+        assertEquals(expected, actual);
+    }
+}

--- a/src/test/java/com/squareup/connect/api/V1EmployeesApiTest.java
+++ b/src/test/java/com/squareup/connect/api/V1EmployeesApiTest.java
@@ -35,7 +35,7 @@ public class V1EmployeesApiTest {
 
     private final V1EmployeesApi api = new V1EmployeesApi();
 
-    
+
     /**
      * Creates an employee for a business.
      *
@@ -51,7 +51,7 @@ public class V1EmployeesApiTest {
 
         // TODO: test validations
     }
-    
+
     /**
      * Creates an employee role you can then assign to employees.
      *
@@ -67,7 +67,7 @@ public class V1EmployeesApiTest {
 
         // TODO: test validations
     }
-    
+
     /**
      * Creates a timecard for an employee. Each timecard corresponds to a single shift.
      *
@@ -83,7 +83,7 @@ public class V1EmployeesApiTest {
 
         // TODO: test validations
     }
-    
+
     /**
      * Deletes a timecard. Deleted timecards are still accessible from Connect API endpoints, but the value of their deleted field is set to true. See Handling deleted timecards for more information.
      *
@@ -99,7 +99,7 @@ public class V1EmployeesApiTest {
 
         // TODO: test validations
     }
-    
+
     /**
      * Provides the details for all of a location&#39;s cash drawer shifts during a date range. The date range you specify cannot exceed 90 days.
      *
@@ -118,7 +118,7 @@ public class V1EmployeesApiTest {
 
         // TODO: test validations
     }
-    
+
     /**
      * Provides summary information for all of a business&#39;s employee roles.
      *
@@ -136,7 +136,7 @@ public class V1EmployeesApiTest {
 
         // TODO: test validations
     }
-    
+
     /**
      * Provides summary information for all of a business&#39;s employees.
      *
@@ -155,11 +155,11 @@ public class V1EmployeesApiTest {
         String status = null;
         String externalId = null;
         Integer limit = null;
-        List<V1Employee> response = api.listEmployees(order, beginUpdatedAt, endUpdatedAt, beginCreatedAt, endCreatedAt, status, externalId, limit);
+        List<V1Employee> response = api.listEmployees(order, beginUpdatedAt, endUpdatedAt, beginCreatedAt, endCreatedAt, status, externalId, limit, null);
 
         // TODO: test validations
     }
-    
+
     /**
      * Provides summary information for all events associated with a particular timecard.
      *
@@ -175,7 +175,7 @@ public class V1EmployeesApiTest {
 
         // TODO: test validations
     }
-    
+
     /**
      * Provides summary information for all of a business&#39;s employee timecards.
      *
@@ -201,7 +201,7 @@ public class V1EmployeesApiTest {
 
         // TODO: test validations
     }
-    
+
     /**
      * Provides the details for a single cash drawer shift, including all events that occurred during the shift.
      *
@@ -218,7 +218,7 @@ public class V1EmployeesApiTest {
 
         // TODO: test validations
     }
-    
+
     /**
      * Provides the details for a single employee.
      *
@@ -234,7 +234,7 @@ public class V1EmployeesApiTest {
 
         // TODO: test validations
     }
-    
+
     /**
      * Provides the details for a single employee role.
      *
@@ -250,7 +250,7 @@ public class V1EmployeesApiTest {
 
         // TODO: test validations
     }
-    
+
     /**
      * Provides the details for a single timecard.
      *
@@ -266,11 +266,11 @@ public class V1EmployeesApiTest {
 
         // TODO: test validations
     }
-    
+
     /**
      * V1 UpdateEmployee
      *
-     * 
+     *
      *
      * @throws ApiException
      *          if the Api call fails
@@ -283,7 +283,7 @@ public class V1EmployeesApiTest {
 
         // TODO: test validations
     }
-    
+
     /**
      * Modifies the details of an employee role.
      *
@@ -300,7 +300,7 @@ public class V1EmployeesApiTest {
 
         // TODO: test validations
     }
-    
+
     /**
      * Modifies a timecard&#39;s details. This creates an API_EDIT event for the timecard. You can view a timecard&#39;s event history with the List Timecard Events endpoint.
      *
@@ -317,5 +317,5 @@ public class V1EmployeesApiTest {
 
         // TODO: test validations
     }
-    
+
 }

--- a/src/test/java/com/squareup/connect/api/V1ItemsApiTest.java
+++ b/src/test/java/com/squareup/connect/api/V1ItemsApiTest.java
@@ -42,7 +42,7 @@ public class V1ItemsApiTest {
 
     private final V1ItemsApi api = new V1ItemsApi();
 
-    
+
     /**
      * Adjusts an item variation&#39;s current available inventory.
      *
@@ -60,7 +60,7 @@ public class V1ItemsApiTest {
 
         // TODO: test validations
     }
-    
+
     /**
      * Associates a fee with an item, meaning the fee is automatically applied to the item in Square Register.
      *
@@ -78,7 +78,7 @@ public class V1ItemsApiTest {
 
         // TODO: test validations
     }
-    
+
     /**
      * Associates a modifier list with an item, meaning modifier options from the list can be applied to the item.
      *
@@ -96,7 +96,7 @@ public class V1ItemsApiTest {
 
         // TODO: test validations
     }
-    
+
     /**
      * Creates an item category.
      *
@@ -113,7 +113,7 @@ public class V1ItemsApiTest {
 
         // TODO: test validations
     }
-    
+
     /**
      * Creates a discount.
      *
@@ -130,7 +130,7 @@ public class V1ItemsApiTest {
 
         // TODO: test validations
     }
-    
+
     /**
      * Creates a fee (tax).
      *
@@ -147,7 +147,7 @@ public class V1ItemsApiTest {
 
         // TODO: test validations
     }
-    
+
     /**
      * Creates an item and at least one variation for it.
      *
@@ -164,7 +164,7 @@ public class V1ItemsApiTest {
 
         // TODO: test validations
     }
-    
+
     /**
      * Creates an item modifier list and at least one modifier option for it.
      *
@@ -181,7 +181,7 @@ public class V1ItemsApiTest {
 
         // TODO: test validations
     }
-    
+
     /**
      * Creates an item modifier option and adds it to a modifier list.
      *
@@ -199,7 +199,7 @@ public class V1ItemsApiTest {
 
         // TODO: test validations
     }
-    
+
     /**
      * Creates a Favorites page in Square Register.
      *
@@ -216,7 +216,7 @@ public class V1ItemsApiTest {
 
         // TODO: test validations
     }
-    
+
     /**
      * Creates an item variation for an existing item.
      *
@@ -234,7 +234,7 @@ public class V1ItemsApiTest {
 
         // TODO: test validations
     }
-    
+
     /**
      * Deletes an existing item category.
      *
@@ -251,7 +251,7 @@ public class V1ItemsApiTest {
 
         // TODO: test validations
     }
-    
+
     /**
      * Deletes an existing discount.
      *
@@ -268,7 +268,7 @@ public class V1ItemsApiTest {
 
         // TODO: test validations
     }
-    
+
     /**
      * Deletes an existing fee (tax).
      *
@@ -285,7 +285,7 @@ public class V1ItemsApiTest {
 
         // TODO: test validations
     }
-    
+
     /**
      * Deletes an existing item and all item variations associated with it.
      *
@@ -302,7 +302,7 @@ public class V1ItemsApiTest {
 
         // TODO: test validations
     }
-    
+
     /**
      * Deletes an existing item modifier list and all modifier options associated with it.
      *
@@ -319,7 +319,7 @@ public class V1ItemsApiTest {
 
         // TODO: test validations
     }
-    
+
     /**
      * Deletes an existing item modifier option from a modifier list.
      *
@@ -337,7 +337,7 @@ public class V1ItemsApiTest {
 
         // TODO: test validations
     }
-    
+
     /**
      * Deletes an existing Favorites page and all of its cells.
      *
@@ -354,7 +354,7 @@ public class V1ItemsApiTest {
 
         // TODO: test validations
     }
-    
+
     /**
      * Deletes a cell from a Favorites page in Square Register.
      *
@@ -373,7 +373,7 @@ public class V1ItemsApiTest {
 
         // TODO: test validations
     }
-    
+
     /**
      * Deletes an existing item variation from an item.
      *
@@ -391,7 +391,7 @@ public class V1ItemsApiTest {
 
         // TODO: test validations
     }
-    
+
     /**
      * Lists all of a location&#39;s item categories.
      *
@@ -407,7 +407,7 @@ public class V1ItemsApiTest {
 
         // TODO: test validations
     }
-    
+
     /**
      * Lists all of a location&#39;s discounts.
      *
@@ -423,7 +423,7 @@ public class V1ItemsApiTest {
 
         // TODO: test validations
     }
-    
+
     /**
      * Lists all of a location&#39;s fees (taxes).
      *
@@ -439,7 +439,7 @@ public class V1ItemsApiTest {
 
         // TODO: test validations
     }
-    
+
     /**
      * Provides inventory information for all of a merchant&#39;s inventory-enabled item variations.
      *
@@ -452,11 +452,11 @@ public class V1ItemsApiTest {
     public void listInventoryTest() throws ApiException {
         String locationId = null;
         Integer limit = null;
-        List<V1InventoryEntry> response = api.listInventory(locationId, limit);
+        List<V1InventoryEntry> response = api.listInventory(locationId, limit, null);
 
         // TODO: test validations
     }
-    
+
     /**
      * Provides summary information for all of a location&#39;s items.
      *
@@ -468,11 +468,11 @@ public class V1ItemsApiTest {
     @Test
     public void listItemsTest() throws ApiException {
         String locationId = null;
-        List<V1Item> response = api.listItems(locationId);
+        List<V1Item> response = api.listItems(locationId, null);
 
         // TODO: test validations
     }
-    
+
     /**
      * Lists all of a location&#39;s modifier lists.
      *
@@ -488,7 +488,7 @@ public class V1ItemsApiTest {
 
         // TODO: test validations
     }
-    
+
     /**
      * Lists all of a location&#39;s Favorites pages in Square Register.
      *
@@ -504,7 +504,7 @@ public class V1ItemsApiTest {
 
         // TODO: test validations
     }
-    
+
     /**
      * Removes a fee assocation from an item, meaning the fee is no longer automatically applied to the item in Square Register.
      *
@@ -522,7 +522,7 @@ public class V1ItemsApiTest {
 
         // TODO: test validations
     }
-    
+
     /**
      * Removes a modifier list association from an item, meaning modifier options from the list can no longer be applied to the item.
      *
@@ -540,7 +540,7 @@ public class V1ItemsApiTest {
 
         // TODO: test validations
     }
-    
+
     /**
      * Provides the details for a single item, including associated modifier lists and fees.
      *
@@ -557,7 +557,7 @@ public class V1ItemsApiTest {
 
         // TODO: test validations
     }
-    
+
     /**
      * Provides the details for a single modifier list.
      *
@@ -574,7 +574,7 @@ public class V1ItemsApiTest {
 
         // TODO: test validations
     }
-    
+
     /**
      * Modifies the details of an existing item category.
      *
@@ -592,7 +592,7 @@ public class V1ItemsApiTest {
 
         // TODO: test validations
     }
-    
+
     /**
      * Modifies the details of an existing discount.
      *
@@ -610,7 +610,7 @@ public class V1ItemsApiTest {
 
         // TODO: test validations
     }
-    
+
     /**
      * Modifies the details of an existing fee (tax).
      *
@@ -628,7 +628,7 @@ public class V1ItemsApiTest {
 
         // TODO: test validations
     }
-    
+
     /**
      * Modifies the core details of an existing item.
      *
@@ -646,7 +646,7 @@ public class V1ItemsApiTest {
 
         // TODO: test validations
     }
-    
+
     /**
      * Modifies the details of an existing item modifier list.
      *
@@ -664,7 +664,7 @@ public class V1ItemsApiTest {
 
         // TODO: test validations
     }
-    
+
     /**
      * Modifies the details of an existing item modifier option.
      *
@@ -683,7 +683,7 @@ public class V1ItemsApiTest {
 
         // TODO: test validations
     }
-    
+
     /**
      * Modifies the details of a Favorites page in Square Register.
      *
@@ -701,7 +701,7 @@ public class V1ItemsApiTest {
 
         // TODO: test validations
     }
-    
+
     /**
      * Modifies a cell of a Favorites page in Square Register.
      *
@@ -719,7 +719,7 @@ public class V1ItemsApiTest {
 
         // TODO: test validations
     }
-    
+
     /**
      * Modifies the details of an existing item variation.
      *
@@ -738,5 +738,5 @@ public class V1ItemsApiTest {
 
         // TODO: test validations
     }
-    
+
 }

--- a/src/test/java/com/squareup/connect/api/V1TransactionsApiTest.java
+++ b/src/test/java/com/squareup/connect/api/V1TransactionsApiTest.java
@@ -37,7 +37,7 @@ public class V1TransactionsApiTest {
 
     private final V1TransactionsApi api = new V1TransactionsApi();
 
-    
+
     /**
      * Issues a refund for a previously processed payment. You must issue a refund within 60 days of the associated payment.
      *
@@ -54,7 +54,7 @@ public class V1TransactionsApiTest {
 
         // TODO: test validations
     }
-    
+
     /**
      * Provides non-confidential details for all of a location&#39;s associated bank accounts. This endpoint does not provide full bank account numbers, and there is no way to obtain a full bank account number with the Connect API.
      *
@@ -70,7 +70,7 @@ public class V1TransactionsApiTest {
 
         // TODO: test validations
     }
-    
+
     /**
      * Provides summary information for a merchant&#39;s online store orders.
      *
@@ -84,11 +84,11 @@ public class V1TransactionsApiTest {
         String locationId = null;
         String order = null;
         Integer limit = null;
-        List<V1Order> response = api.listOrders(locationId, order, limit);
+        List<V1Order> response = api.listOrders(locationId, order, limit, null);
 
         // TODO: test validations
     }
-    
+
     /**
      * Provides summary information for all payments taken by a merchant or any of the merchant&#39;s mobile staff during a date range. Date ranges cannot exceed one year in length. See Date ranges for details of inclusive and exclusive dates.
      *
@@ -104,11 +104,11 @@ public class V1TransactionsApiTest {
         String beginTime = null;
         String endTime = null;
         Integer limit = null;
-        List<V1Payment> response = api.listPayments(locationId, order, beginTime, endTime, limit);
+        List<V1Payment> response = api.listPayments(locationId, order, beginTime, endTime, limit, null);
 
         // TODO: test validations
     }
-    
+
     /**
      * Provides the details for all refunds initiated by a merchant or any of the merchant&#39;s mobile staff during a date range. Date ranges cannot exceed one year in length.
      *
@@ -124,15 +124,15 @@ public class V1TransactionsApiTest {
         String beginTime = null;
         String endTime = null;
         Integer limit = null;
-        List<V1Refund> response = api.listRefunds(locationId, order, beginTime, endTime, limit);
+        List<V1Refund> response = api.listRefunds(locationId, order, beginTime, endTime, limit, null);
 
         // TODO: test validations
     }
-    
+
     /**
      * Provides summary information for all deposits and withdrawals initiated by Square to a merchant&#39;s bank account during a date range. Date ranges cannot exceed one year in length.
      *
-     * Provides summary information for all deposits and withdrawals initiated by Square to a merchant&#39;s bank account during a date range. Date ranges cannot exceed one year in length. 
+     * Provides summary information for all deposits and withdrawals initiated by Square to a merchant&#39;s bank account during a date range. Date ranges cannot exceed one year in length.
      *
      * @throws ApiException
      *          if the Api call fails
@@ -145,11 +145,11 @@ public class V1TransactionsApiTest {
         String endTime = null;
         Integer limit = null;
         String status = null;
-        List<V1Settlement> response = api.listSettlements(locationId, order, beginTime, endTime, limit, status);
+        List<V1Settlement> response = api.listSettlements(locationId, order, beginTime, endTime, limit, status, null);
 
         // TODO: test validations
     }
-    
+
     /**
      * Provides non-confidential details for a merchant&#39;s associated bank account. This endpoint does not provide full bank account numbers, and there is no way to obtain a full bank account number with the Connect API.
      *
@@ -166,7 +166,7 @@ public class V1TransactionsApiTest {
 
         // TODO: test validations
     }
-    
+
     /**
      * Provides comprehensive information for a single online store order, including the order&#39;s history.
      *
@@ -183,7 +183,7 @@ public class V1TransactionsApiTest {
 
         // TODO: test validations
     }
-    
+
     /**
      * Provides comprehensive information for a single payment.
      *
@@ -200,7 +200,7 @@ public class V1TransactionsApiTest {
 
         // TODO: test validations
     }
-    
+
     /**
      * Provides comprehensive information for a single settlement, including the entries that contribute to the settlement&#39;s total.
      *
@@ -217,7 +217,7 @@ public class V1TransactionsApiTest {
 
         // TODO: test validations
     }
-    
+
     /**
      * Updates the details of an online store order. Every update you perform on an order corresponds to one of three actions:
      *
@@ -235,5 +235,5 @@ public class V1TransactionsApiTest {
 
         // TODO: test validations
     }
-    
+
 }


### PR DESCRIPTION
This PR adds acceptance test for the orders API. Since the orders API builds on the catalog API, I moved some of the helper functions in `CatalogApiTest` to a shared helper class.